### PR TITLE
Label managed namespaces for custom-CA trust fan-out (Quix 73259)

### DIFF
--- a/build/dockerfile
+++ b/build/dockerfile
@@ -19,11 +19,7 @@ RUN find ./api -type f -name "zz_*" -delete
 COPY config/ ./config/
 COPY LICENSE ./LICENSE
 
-# Download dependencies against the committed go.sum. No 'go mod tidy' here:
-# tidy re-resolves the graph and drifts transitive deps past the pinned
-# versions (e.g. k8s.io/apimachinery v0.36.2 needs go >= 1.26, breaking the
-# go 1.24 / GOTOOLCHAIN=local builder). go.sum is committed, so download is
-# reproducible.
+# Download dependencies pinned by the committed go.sum.
 RUN go mod download
 
 # Build

--- a/build/dockerfile
+++ b/build/dockerfile
@@ -19,9 +19,12 @@ RUN find ./api -type f -name "zz_*" -delete
 COPY config/ ./config/
 COPY LICENSE ./LICENSE
 
-# Download dependencies and generate go.sum
+# Download dependencies against the committed go.sum. No 'go mod tidy' here:
+# tidy re-resolves the graph and drifts transitive deps past the pinned
+# versions (e.g. k8s.io/apimachinery v0.36.2 needs go >= 1.26, breaking the
+# go 1.24 / GOTOOLCHAIN=local builder). go.sum is committed, so download is
+# reproducible.
 RUN go mod download
-RUN go mod tidy
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 make build

--- a/hack/setup-dev-env.sh
+++ b/hack/setup-dev-env.sh
@@ -47,7 +47,9 @@ test -s $LOCALBIN/controller-gen || GOARCH=$(go env GOARCH) GOBIN=$LOCALBIN GOTO
 test -s $LOCALBIN/setup-envtest || GOARCH=$(go env GOARCH) GOBIN=$LOCALBIN GOTOOLCHAIN=local go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$SETUP_ENVTEST_VERSION
 
 go mod download
-go mod tidy
+# No 'go mod tidy' here: the docker build runs setup-dev before the source is
+# copied in, so tidy would strip go.mod to nothing. go.mod/go.sum are committed
+# and complete; run 'make tidy' explicitly when changing dependencies.
 
 # Download kubebuilder assets
 echo "Downloading kubebuilder assets for testing..."

--- a/hack/setup-dev-env.sh
+++ b/hack/setup-dev-env.sh
@@ -47,9 +47,6 @@ test -s $LOCALBIN/controller-gen || GOARCH=$(go env GOARCH) GOBIN=$LOCALBIN GOTO
 test -s $LOCALBIN/setup-envtest || GOARCH=$(go env GOARCH) GOBIN=$LOCALBIN GOTOOLCHAIN=local go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$SETUP_ENVTEST_VERSION
 
 go mod download
-# No 'go mod tidy' here: the docker build runs setup-dev before the source is
-# copied in, so tidy would strip go.mod to nothing. go.mod/go.sum are committed
-# and complete; run 'make tidy' explicitly when changing dependencies.
 
 # Download kubebuilder assets
 echo "Downloading kubebuilder assets for testing..."

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -1293,7 +1293,7 @@ var _ = Describe("Environment controller integration tests", func() {
 				Expect(createdNs.Labels["quix.io/managed-by"]).To(Equal("quix-environment-operator"))
 				Expect(createdNs.Labels["quix.io/environment-id"]).To(Equal("test-metadata-override"))
 				Expect(createdNs.Labels["quix.io/environment-name"]).To(Equal(env.Name))
-				Expect(createdNs.Labels["quix.io/trust-custom-ca"]).To(Equal("true"))
+				Expect(createdNs.Labels["ManagedBy"]).To(Equal("Quix"))
 
 				// Clean up
 				Expect(k8sClient.Delete(ctx, env)).Should(Succeed())

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -1293,6 +1293,7 @@ var _ = Describe("Environment controller integration tests", func() {
 				Expect(createdNs.Labels["quix.io/managed-by"]).To(Equal("quix-environment-operator"))
 				Expect(createdNs.Labels["quix.io/environment-id"]).To(Equal("test-metadata-override"))
 				Expect(createdNs.Labels["quix.io/environment-name"]).To(Equal(env.Name))
+				Expect(createdNs.Labels["quix.io/trust-custom-ca"]).To(Equal("true"))
 
 				// Clean up
 				Expect(k8sClient.Delete(ctx, env)).Should(Succeed())

--- a/internal/resources/namespace/manager.go
+++ b/internal/resources/namespace/manager.go
@@ -21,6 +21,9 @@ const (
 	OperatorName           = "quix-environment-operator"
 	LabelEnvironmentID     = "quix.io/environment-id"
 	LabelEnvironmentName   = "quix.io/environment-name"
+	// LabelTrustCustomCA marks namespaces for custom-CA fan-out by the platform's
+	// trust-manager Bundle (Quix 73259). The Bundle's namespaceSelector matches it.
+	LabelTrustCustomCA = "quix.io/trust-custom-ca"
 	AnnotationCreatedBy    = "quix.io/created-by"
 	AnnotationCRDNamespace = "quix.io/environment-crd-namespace"
 	AnnotationResourceName = "quix.io/environment-resource-name"
@@ -243,6 +246,7 @@ func (m *DefaultManager) ApplyMetadata(env *v1.Environment, namespace *corev1.Na
 		ManagedByLabel:       OperatorName,
 		LabelEnvironmentID:   env.Spec.Id,
 		LabelEnvironmentName: env.Name,
+		LabelTrustCustomCA:   "true",
 	}
 
 	for key, value := range requiredLabels {
@@ -257,6 +261,7 @@ func (m *DefaultManager) ApplyMetadata(env *v1.Environment, namespace *corev1.Na
 		ManagedByLabel,
 		LabelEnvironmentID,
 		LabelEnvironmentName,
+		LabelTrustCustomCA,
 		"kubernetes.io/metadata.name",
 		"control-plane",
 	}

--- a/internal/resources/namespace/manager.go
+++ b/internal/resources/namespace/manager.go
@@ -21,8 +21,7 @@ const (
 	OperatorName           = "quix-environment-operator"
 	LabelEnvironmentID     = "quix.io/environment-id"
 	LabelEnvironmentName   = "quix.io/environment-name"
-	// LabelTrustCustomCA marks namespaces for custom-CA fan-out by the platform's
-	// trust-manager Bundle (Quix 73259). The Bundle's namespaceSelector matches it.
+	// LabelTrustCustomCA marks namespaces for the platform trust-manager custom-CA Bundle (Quix 73259).
 	LabelTrustCustomCA = "quix.io/trust-custom-ca"
 	AnnotationCreatedBy    = "quix.io/created-by"
 	AnnotationCRDNamespace = "quix.io/environment-crd-namespace"

--- a/internal/resources/namespace/manager.go
+++ b/internal/resources/namespace/manager.go
@@ -21,8 +21,9 @@ const (
 	OperatorName           = "quix-environment-operator"
 	LabelEnvironmentID     = "quix.io/environment-id"
 	LabelEnvironmentName   = "quix.io/environment-name"
-	// LabelTrustCustomCA marks namespaces for the platform trust-manager custom-CA Bundle (Quix 73259).
-	LabelTrustCustomCA = "quix.io/trust-custom-ca"
+	// PlatformManagedByLabel marks namespaces for the platform trust-manager custom-CA Bundle (Quix 73259).
+	PlatformManagedByLabel = "ManagedBy"
+	PlatformManagedByValue = "Quix"
 	AnnotationCreatedBy    = "quix.io/created-by"
 	AnnotationCRDNamespace = "quix.io/environment-crd-namespace"
 	AnnotationResourceName = "quix.io/environment-resource-name"
@@ -242,10 +243,10 @@ func (m *DefaultManager) ApplyMetadata(env *v1.Environment, namespace *corev1.Na
 
 	// Ensure required labels are set
 	requiredLabels := map[string]string{
-		ManagedByLabel:       OperatorName,
-		LabelEnvironmentID:   env.Spec.Id,
-		LabelEnvironmentName: env.Name,
-		LabelTrustCustomCA:   "true",
+		ManagedByLabel:         OperatorName,
+		LabelEnvironmentID:     env.Spec.Id,
+		LabelEnvironmentName:   env.Name,
+		PlatformManagedByLabel: PlatformManagedByValue,
 	}
 
 	for key, value := range requiredLabels {
@@ -260,7 +261,7 @@ func (m *DefaultManager) ApplyMetadata(env *v1.Environment, namespace *corev1.Na
 		ManagedByLabel,
 		LabelEnvironmentID,
 		LabelEnvironmentName,
-		LabelTrustCustomCA,
+		PlatformManagedByLabel,
 		"kubernetes.io/metadata.name",
 		"control-plane",
 	}


### PR DESCRIPTION
 Features
  - Stamp the platform-wide ManagedBy=Quix label on every operator-managed namespace (added to both the required and protected label sets, so it cannot be overridden via Environment.spec.labels). This lets the platform trust-manager custom-CA Bundle, which already selects on ManagedBy=Quix, fan the custom CA into operator-managed namespaces with no platform-side changes.

 Fixes
  - Make the docker build reproducible and unbreak it: the image ran go mod tidy at build time (in both build/dockerfile and hack/setup-dev-env.sh, the latter before the source was even copied in), which re-resolved the module graph and drifted transitive deps to the latest (k8s.io/apimachinery v0.36.2, requiring go >= 1.26) on the go 1.24 / GOTOOLCHAIN=local builder. Removed both build-time tidy calls and rely on the committed go.mod/go.sum via go mod download; run make tidy explicitly when changing dependencies.