### PR TITLE
Bump operator release to 0.1.6

### DIFF
--- a/.github/GHACTION_README.md
+++ b/.github/GHACTION_README.md
@@ -7,7 +7,7 @@ The `build.yml` workflow handles testing, building, and publishing Docker images
 1. Runs tests in Docker to ensure code quality
 2. Builds the Docker image 
 3. Pushes the Docker image to Docker Hub
-4. Packages and pushes the Helm chart as an OCI artifact
+4. Packages and publishes the Helm chart to the GitHub Pages Helm repository
 
 ### Version Handling
 
@@ -40,4 +40,4 @@ The workflow runs on:
 - Pull requests targeting the `main` branch
 - Manual trigger via GitHub UI
 
-Note: Docker image push and Helm chart push only happen on push to `main` or manual trigger, not on pull requests. 
+Note: Pull request runs use development versioning; publishing from those runs depends on the repository token and secret permissions available to the workflow.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Packaged as a Helm chart for customer-managed Kubernetes clusters. Operates with
 
 Install a specific version
 ```
-operator_version=0.1.5
+operator_version=0.1.6
 operator_env_regex=""
 helm repo add quix-environment-operator https://quixio.github.io/quix-environment-operator/ && helm repo update
 helm pull quix-environment-operator/quix-environment-operator --version $operator_version

--- a/deploy/quix-environment-operator/Chart.yaml
+++ b/deploy/quix-environment-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: quix-environment-operator
 description: A Kubernetes operator for provisioning isolated application environments
 type: application
-version: 0.1.5
-appVersion: "0.1.5"
+version: 0.1.6
+appVersion: "0.1.6"
 icon: https://quixstorageaccount.blob.core.windows.net/portal/img/quix_favicon.png
 keywords:
   - quix
@@ -15,4 +15,4 @@ maintainers:
     email: devs@quix.io
 home: https://github.com/quix-analytics/quix-environment-operator
 sources:
-  - https://github.com/quix-analytics/quix-environment-operator 
+  - https://github.com/quix-analytics/quix-environment-operator


### PR DESCRIPTION
Docs:
- Update install example and workflow publishing description Other:
- Set Helm chart and app versions to 0.1.6